### PR TITLE
Fix a minor typo

### DIFF
--- a/chinese-pyim.org
+++ b/chinese-pyim.org
@@ -222,7 +222,7 @@ C-h v pyim-fuzzy-pinyin-adjust-function
 #+END_SRC
 
 可以通过 pyim-company-predict-words-number 来设置联想词的数量，
-比如：从词库中搜索10个联想词可以设置为：。
+比如：从词库中搜索10个联想词可以设置为：
 
 #+BEGIN_SRC emacs-lisp
 (setq pyim-company-predict-words-number 10)


### PR DESCRIPTION
我不知道如何（正确地）生成 `*.el` 和 `README.md`：在`chinese-pyim.org`中运行`M-x org-babel-tangle RET y RET` 生成的`*.e` 与你的不匹配，即使我什么都没有修改。而用 `org-md-export-to-markdown` 生成的 `README.md` 不同之处就更多了。

能不能解释下应该如何做呢？

PS. 我的 org-mode 版本是 "8.2.10"。